### PR TITLE
Fix smaller function signature issues

### DIFF
--- a/source/metal/metal.d
+++ b/source/metal/metal.d
@@ -999,9 +999,8 @@ interface MTLDrawable
     CFTimeInterval presentedTime();
 }
 
-
-MTLSamplePosition MTLSamplePositionMake(float x, float y);
-MTLCommandBuffer MTLCreateSystemDefaultDevice();
+extern(C) MTLSamplePosition MTLSamplePositionMake(float x, float y);
+extern(C) MTLDevice MTLCreateSystemDefaultDevice();
 
 ///An instance you use to create, submit, and schedule command buffers to a specific GPU device to run the commands within those buffers.
 interface MTLCommandQueue

--- a/source/metal/metal.d
+++ b/source/metal/metal.d
@@ -1151,6 +1151,8 @@ class CAMetalLayer
 
     @selector("device")
     MTLDevice device();
+    @selector("setDevice:")
+    MTLDevice device(MTLDevice);
 
     @selector("drawableSize")
     CGSize drawableSize();


### PR DESCRIPTION
This PR fixes MTLCreateSystemDefaultDevice's signature being wrong, and `setDevice:` not being defined in CAMetalLayer